### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing "GitHub Skills" activity that was announced by the principal.

## Changes
- Added "GitHub Skills" to the activities list in `app.py`
- Configured with appropriate schedule, capacity, and description
- Part of the GitHub Certifications program mentioned in the principal's announcement

## Resolves
Fixes #6

## Details
- **Schedule:** Mondays and Wednesdays, 3:30 PM - 5:00 PM
- **Max Participants:** 25 students
- **Description:** Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications.

This is time-sensitive as registrations need to be available by end of week as mentioned in the issue.